### PR TITLE
Reduce bundle size by removing `object.values` library

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "airbnb-prop-types": "^2.10.0",
     "consolidated-events": "^1.1.1 || ^2.0.0",
-    "object.values": "^1.0.4",
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {

--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -4,22 +4,14 @@ import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
 
+// Remember to keep `DISPLAY` and the below `DISPLAY_VALUES` in sync.
 const DISPLAY = {
   BLOCK: 'block',
   FLEX: 'flex',
   INLINE_BLOCK: 'inline-block',
 };
 
-// Use `for..in` loop in place of `Object.values` since we only
-// use `DISPLAY_VALUES` for prop validation.
-const DISPLAY_VALUES = [];
-/* eslint-disable no-restricted-syntax */
-for (const displayType in DISPLAY) {
-  if (Object.prototype.propertyIsEnumerable.call(DISPLAY, displayType)) {
-    DISPLAY_VALUES.push(DISPLAY[displayType]);
-  }
-}
-/* eslint-enable no-restricted-syntax */
+const DISPLAY_VALUES = ['block', 'flex', 'inline-block'];
 
 const propTypes = forbidExtraProps({
   children: PropTypes.node.isRequired,

--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
-import objectValues from 'object.values';
 
 const DISPLAY = {
   BLOCK: 'block',
@@ -11,12 +10,23 @@ const DISPLAY = {
   INLINE_BLOCK: 'inline-block',
 };
 
+// Use `for..in` loop in place of `Object.values` since we only
+// use `DISPLAY_VALUES` for prop validation.
+const DISPLAY_VALUES = [];
+/* eslint-disable no-restricted-syntax */
+for (const displayType in DISPLAY) {
+  if (Object.prototype.propertyIsEnumerable.call(DISPLAY, displayType)) {
+    DISPLAY_VALUES.push(DISPLAY[displayType]);
+  }
+}
+/* eslint-enable no-restricted-syntax */
+
 const propTypes = forbidExtraProps({
   children: PropTypes.node.isRequired,
   onOutsideClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
   useCapture: PropTypes.bool,
-  display: PropTypes.oneOf(objectValues(DISPLAY)),
+  display: PropTypes.oneOf(DISPLAY_VALUES),
 });
 
 const defaultProps = {
@@ -115,7 +125,7 @@ export default class OutsideClickHandler extends React.Component {
       <div
         ref={this.setChildNodeRef}
         style={
-          display !== DISPLAY.BLOCK && objectValues(DISPLAY).includes(display)
+          display !== DISPLAY.BLOCK && DISPLAY_VALUES.includes(display)
             ? { display }
             : undefined
         }


### PR DESCRIPTION
I know #7 was closed but I figured I'd introduce the PR anyway even if it is rejected.

I did have to disable the [eslint no-restricted-syntax](https://eslint.org/docs/rules/no-restricted-syntax) rule because it didn't like the `for..in` loop.

As previously mentioned, I completely see the merits in being wary of `for..in` loops because of its unintuitive side effects, and why solutions like `Object.values` are more robust.

However, in this specific case, I don't see much danger in using a `for..in` loop to create an array of values that are only used for prop validation.

Thanks.