### PR TITLE
Add definitely typed badge and definitions url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # react-outside-click-handler
 
+[![TypeScript typings](https://img.shields.io/badge/definetly_typed-.d.ts-blue.svg?style=flat-square)](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-outside-click-handler)
+
 > A React component for handling outside clicks
 
 ## Usage


### PR DESCRIPTION
Adds a link to typescript DefinitelyTyped repo and a badge to indicate the existence of those typings.

Typings are already published to npm, see https://www.npmjs.com/package/@types/react-outside-click-handler

Going to look like this:
[![TypeScript typings](https://img.shields.io/badge/definetly_typed-.d.ts-blue.svg?style=flat-square)](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-outside-click-handler)