### PR TITLE
[Fix] Prevent outside click events for unmounted component

### DIFF
--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -37,9 +37,11 @@ export default class OutsideClickHandler extends React.Component {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.setChildNodeRef = this.setChildNodeRef.bind(this);
+    this._isMounted = false;
   }
 
   componentDidMount() {
+    this._isMounted = true;
     const { disabled, useCapture } = this.props;
 
     if (!disabled) this.addMouseDownEventListener(useCapture);
@@ -57,6 +59,7 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     this.removeEventListeners();
   }
 
@@ -87,7 +90,7 @@ export default class OutsideClickHandler extends React.Component {
     if (this.removeMouseUp) this.removeMouseUp();
     this.removeMouseUp = null;
 
-    if (!isDescendantOfRoot) {
+    if (this._isMounted && !isDescendantOfRoot) {
       onOutsideClick(e);
     }
   }


### PR DESCRIPTION
I have two nested components, each wrapped into own **OutsideClickHandler**. Both components is unmouning on outside clicks by calling a handler function. This handler functions are located in their parents and passed to the components in props. Handler functions are setting **this.state** which in turn unmount the child (our component, wrapped into **OutsideClickHandler**).

The problem appears when user make click out of the outer component of this pair. In this case the click event is emitting for both **OutsideClickHandler** components but the order of called handlers is:
1. outer/parent component
2. inner/child component

And therefore the **inner/child** component receive the outside click event after **outer/parent** component unmounted. In turn it's also trying to set **state** to unmount itself. At this moment the ReactJs show his warning:
> Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

I see that current implementation removes event listeners in the **componentWillUnmount** but this is not enough in the case of nested components, because event is already in queue and will call the handler anyway even after component is unmouned.
