### PR TITLE
[New] `display`: add `inline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ See https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Ev
 
 If `useCapture` is true, the event will be registered in the capturing phase and thus, propagated top-down instead of bottom-up as is the default.
 
-### display: `PropTypes.oneOf(['block', 'flex', 'inline-block'])`
+### display: `PropTypes.oneOf(['block', 'flex', 'inline-block', 'inline'])`
 
-By default, the `OutsideClickHandler` renders a `display: block` `<div />` to wrap the subtree defined by `children`. If desired, the `display` can be set to `inline-block` or `flex` instead. There is no way not to render a wrapping `<div />`.
+By default, the `OutsideClickHandler` renders a `display: block` `<div />` to wrap the subtree defined by `children`. If desired, the `display` can be set to `inline-block`, `inline`, or `flex` instead. There is no way not to render a wrapping `<div />`.

--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -10,6 +10,7 @@ import contains from 'document.contains';
 const DISPLAY = {
   BLOCK: 'block',
   FLEX: 'flex',
+  INLINE: 'inline',
   INLINE_BLOCK: 'inline-block',
 };
 

--- a/test/OutsideClickHandler_test.jsx
+++ b/test/OutsideClickHandler_test.jsx
@@ -161,3 +161,114 @@ describe('OutsideClickHandler', () => {
     });
   });
 });
+
+describe('OutsideClickHandler display=inline', () => {
+  describe('basics', () => {
+    it('renders a div', () => {
+      expect(shallow(<OutsideClickHandler display="inline" />).is('div')).to.equal(true);
+    });
+
+    it('renders the children it‘s given', () => {
+      const wrapper = shallow((
+        <OutsideClickHandler display="inline">
+          <section id="a" />
+          <nav id="b" />
+        </OutsideClickHandler>
+      ));
+      expect(wrapper.children().map(x => ({ type: x.type(), id: x.prop('id') }))).to.eql([
+        { type: 'section', id: 'a' },
+        { type: 'nav', id: 'b' },
+      ]);
+    });
+  });
+
+  describe('#onOutsideClick()', () => {
+    const target = { parentNode: null };
+    const event = { target };
+    beforeEach(() => {
+      target.parentNode = null;
+    });
+
+    it('is a noop if `this.childNode` contains `e.target`', () => {
+      const spy = sinon.spy();
+      const wrapper = shallow(<OutsideClickHandler onOutsideClick={spy} display="inline" />);
+      const instance = wrapper.instance();
+
+      instance.childNode = {};
+      target.parentNode = instance.childNode;
+      expect(contains(instance.childNode, target)).to.equal(true);
+
+      instance.onMouseUp(event);
+
+      expect(spy).to.have.property('callCount', 0);
+    });
+
+    describe('when `this.childNode` does not contain `e.target`', () => {
+      it('calls onOutsideClick', () => {
+        const spy = sinon.spy();
+        const wrapper = shallow(<OutsideClickHandler onOutsideClick={spy} display="inline" />);
+        const instance = wrapper.instance();
+
+        instance.childNode = {};
+        expect(contains(instance.childNode, target)).to.equal(false);
+
+        instance.onMouseUp(event);
+
+        expect(spy).to.have.property('callCount', 1);
+        expect(spy.firstCall.args).to.eql([event]);
+      });
+    });
+  });
+
+  describe.skip('lifecycle methods', () => {
+    wrap()
+    .withOverride(() => document, 'attachEvent', () => sinon.stub())
+    .describe('#componentDidMount', () => {
+      let addEventListenerStub;
+      beforeEach(() => {
+        addEventListenerStub = sinon.stub(document, 'addEventListener');
+      });
+
+      it('document.addEventListener is called with `click` & onOutsideClick', () => {
+        const wrapper = mount(<OutsideClickHandler display="inline" />);
+        const { onOutsideClick } = wrapper.instance();
+        expect(addEventListenerStub.calledWith('click', onOutsideClick, true)).to.equal(true);
+      });
+
+      it('document.attachEvent is called if addEventListener is not available', () => {
+        document.addEventListener = undefined;
+
+        const wrapper = mount(<OutsideClickHandler display="inline" />);
+        const { onOutsideClick } = wrapper.instance();
+        expect(document.attachEvent.calledWith('onclick', onOutsideClick)).to.equal(true);
+      });
+    });
+
+    wrap()
+    .withOverride(() => document, 'detachEvent', () => sinon.stub())
+    .describe('#componentWillUnmount', () => {
+      let removeEventListenerSpy;
+      beforeEach(() => {
+        removeEventListenerSpy = sinon.spy(document, 'removeEventListener');
+      });
+
+      it('document.removeEventListener is called with `click` and props.onOutsideClick', () => {
+        const wrapper = mount(<OutsideClickHandler display="inline" />);
+        const { onOutsideClick } = wrapper.instance();
+
+        wrapper.instance().componentWillUnmount();
+        expect(removeEventListenerSpy.calledWith('click', onOutsideClick, true)).to.equal(true);
+      });
+
+      it('document.detachEvent is called if document.removeEventListener is not available', () => {
+        document.removeEventListener = undefined;
+
+        const wrapper = mount(<OutsideClickHandler display="inline" />);
+        const { onOutsideClick } = wrapper.instance();
+
+        wrapper.instance().componentWillUnmount();
+        expect(document.detachEvent.calledWith('onclick', onOutsideClick)).to.equal(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Allow "inline" to be set as display property.

Fixes #27.