### PR TITLE
Replace `componentWillReceiveProps` with `componentDidUpdate`

### DIFF
--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -47,8 +47,8 @@ export default class OutsideClickHandler extends React.Component {
     if (!disabled) this.addMouseDownEventListener(useCapture);
   }
 
-  componentWillReceiveProps({ disabled, useCapture }) {
-    const { disabled: prevDisabled } = this.props;
+  componentDidUpdate({ disabled: prevDisabled }) {
+    const { disabled, useCapture } = this.props;
     if (prevDisabled !== disabled) {
       if (disabled) {
         this.removeEventListeners();


### PR DESCRIPTION
`componentWillReceiveProps` is going to be deprecated, and is giving console warnings to anyone using this lib.

Since the usage just caused a side-effect and didn't modify the state, we can just replace it with `componentDidUpdate` and get the same effect.

Here's a good example:
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#side-effects-on-props-change