### PR TITLE
added className prop to component

### DIFF
--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -21,6 +21,7 @@ const propTypes = forbidExtraProps({
   disabled: PropTypes.bool,
   useCapture: PropTypes.bool,
   display: PropTypes.oneOf(objectValues(DISPLAY)),
+  className: PropTypes.string,
 });
 
 const defaultProps = {
@@ -119,7 +120,7 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   render() {
-    const { children, display } = this.props;
+    const { children, display, className } = this.props;
 
     return (
       <div
@@ -129,6 +130,7 @@ export default class OutsideClickHandler extends React.Component {
             ? { display }
             : undefined
         }
+        className={className}
       >
         {children}
       </div>


### PR DESCRIPTION
I added a className prop to the component,  a very basic yet useful addition in my opinion. The new prop is a string, and gets passed directly to the rendered div.