### PR TITLE
chore: add module property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "A React component for dealing with clicks outside its subtree",
   "main": "index.js",
+  "module": "esm/OutsideClickHandler.js",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm run build:cjs && npm run build:esm",


### PR DESCRIPTION
### What

Since the package has `esm` files. It might be better to add `module` property to `package.json`.